### PR TITLE
fix: production Swagger build + add /git-save command

### DIFF
--- a/.claude/commands/compact.md
+++ b/.claude/commands/compact.md
@@ -6,19 +6,29 @@ Steps:
    - What files were created or modified (list them)
    - Any key architectural decisions made
    - Any open TODOs or things left for next session
-2. Format the summary as a new entry:
+2. Capture the **key/important notes** from this session — the non-obvious knowledge worth keeping even if no context file maps to it. Examples:
+   - Bugs fixed and their root cause (e.g. "fixed Swagger showing the same response for all endpoints — caused by build minification mangling DTO class names; fix was `optimization: false` in `apps/api/project.json`")
+   - Gotchas, footguns, or surprising behavior discovered
+   - Why a decision was made (the reasoning, not just the change)
+   - Anything you'd want a future session to know before touching the same area
+   Save these notes so they persist:
+   - If a relevant context file exists (db.md, api.md, web.md, etc.), add a short note there (e.g. a "Gotchas" or "Notes" line in the relevant section)
+   - Otherwise, always record them in the implementation-log.md entry below — every session's important learnings must end up somewhere in `.claude/context/`
+3. Format the summary as a new entry:
    ```
    ## YYYY-MM-DD — <short session title>
    - bullet 1
    - bullet 2
+   - **Key note:** <root cause / gotcha / decision worth remembering>
    ```
-3. Append this entry to `.claude/context/implementation-log.md`
-4. Also update any context files that are now outdated:
+4. Append this entry to `.claude/context/implementation-log.md`
+5. Also update any context files that are now outdated:
    - If new DB tables were added → update `db.md`
    - If new API endpoints were added → update `api.md`
    - If new pages/features were added → update `web.md`
    - If shared Zod schemas/types changed → update `shared.md`
    - If Cloudflare Worker behavior changed → update `cloudflare.md`
-5. Confirm what was saved and which context files were updated.
+   - If build/tooling/config behavior changed → note it in `project.md`
+6. Confirm what was saved and which context files were updated.
 
-Keep each log entry tight — 5–10 bullets max. Focus on what's non-obvious or wouldn't be derivable from reading the code.
+Keep each log entry tight — 5–10 bullets max. Focus on what's non-obvious or wouldn't be derivable from reading the code. The important-notes capture (step 2) is the priority — never drop a hard-won learning just because it doesn't fit an existing context file.

--- a/.claude/commands/git-save.md
+++ b/.claude/commands/git-save.md
@@ -1,0 +1,31 @@
+Stage all changes and commit them with an appropriate Conventional Commit message based on what was done this session.
+
+Steps:
+1. Run `git branch --show-current`. If it's `main`, warn the user and ask whether to create a new branch before committing (never commit straight to `main`).
+2. Run `git status` and `git diff HEAD` (plus `git diff --staged`) to see exactly what changed — both staged and unstaged.
+3. Run `git log --oneline -5` to match the repo's existing commit-message style.
+4. Decide the commit type from the changes (use the repo's convention):
+   - `feat:` — new feature or endpoint/page/capability
+   - `fix:` — bug fix
+   - `refactor:` — restructure without behavior change
+   - `chore:` — tooling, deps, config, formatting, non-code housekeeping
+   - `ci:` — CI/CD workflow changes
+   - `docs:` — documentation only (incl. `.claude/` context/commands)
+   - If changes span multiple types, pick the dominant one; if they're truly unrelated, tell the user and suggest splitting into separate commits.
+5. Stage everything: `git add -A`
+6. Write a concise message: `<type>: <imperative summary under 70 chars>`. Add a short body only if the change needs context (what + why, not how).
+7. Commit. Use a HEREDOC for the message so multi-line bodies format correctly:
+   ```
+   git commit -m "$(cat <<'EOF'
+   <type>: <summary>
+
+   <optional body>
+   EOF
+   )"
+   ```
+8. Run `git status` to confirm a clean tree, and print the new commit (`git log --oneline -1`).
+
+Notes:
+- Do NOT push — this command only commits locally. Use `/create-pr` to push and open a PR.
+- Match the existing repo commit style (lowercase type, no trailing period in the summary).
+- If there are no changes to commit, say so and stop.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,8 @@
       "Bash(git diff:*)",
       "Bash(git status:*)",
       "Bash(git branch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
       "Bash(gh:*)",
       "Bash(pnpm:*)",
       "Bash(nx:*)",

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -24,7 +24,7 @@
         },
         "production": {
           "mode": "production",
-          "optimization": true,
+          "optimization": false,
           "sourceMap": false
         }
       }


### PR DESCRIPTION
## Summary
- Fix production Swagger rendering the same response schema for every endpoint and dropping params/query/body
- Root cause: the production api build had `optimization: true`, which minified DTO class names; `nestjs-zod` + `@nestjs/swagger` name OpenAPI component schemas after those class names, so mangling collapsed them into collisions
- Local was unaffected because `nx serve` uses the development config (no minification)
- Add a `/git-save` command for staged Conventional Commits, and update `/compact` to persist key session learnings into context

## Changes
- `apps/api/project.json` — set `optimization: false` for the production build (Nx executor controls minification and overrides rspack.config.js)
- `.claude/commands/git-save.md` — new command
- `.claude/commands/compact.md` — capture important session notes/decisions
- `.claude/settings.json` — allow `git add` / `git commit`

## Test plan
- [ ] `nx build api --configuration=production` succeeds
- [ ] Deployed prod Swagger (`/docs`) shows correct per-endpoint request params and response schemas
- [ ] Each endpoint shows its own response shape (no shared notification schema)
- [ ] API runtime behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development build configuration for the API.
  * Enhanced developer command documentation for improved session management and commit workflows.
  * Updated permissions to enable additional development tooling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->