### PR TITLE
refactor: isolate family-tree access into declarative guards

### DIFF
--- a/.claude/context/api.md
+++ b/.claude/context/api.md
@@ -34,6 +34,8 @@ COOKIE_DOMAIN, COOKIE_CLIENT_URL
 ## Guards & Interceptors
 - `JWTAuthGuard` — validates JWT from cookie, attaches `req.user`
 - `GoogleOauthGuard` — Passport Google strategy
+- `FamilyTreeAccessGuard` (`common/guards/`) — centralizes owner/public/shared access for any route nested under a tree (params `familyTreeId` ?? `id`). Owner → full; public → read-only (rejects if any permission required); shared → must hold every required flag and not be blocked. Must run AFTER `JWTAuthGuard` (`@UseGuards(JWTAuthGuard, FamilyTreeAccessGuard)`). Reads required perms from `@RequirePermission(...)`.
+- `@RequirePermission('canAddMembers', ...)` decorator (`common/decorators/`) — declares which shared-tree flags a route needs; variadic (all must hold). Omit for read-only routes. Must add `FamilyTreeAccessGuard` to the module's `providers` so DI can resolve `DrizzleAsyncProvider`.
 - `FamilyTreeCacheInterceptor` — Redis cache for family tree endpoints
 - `UserCacheInterceptor` — Redis cache for user endpoints
 - `ZodResponseInterceptor` — response shape validation
@@ -143,8 +145,11 @@ Returns: `{ message, path }` where path = `CLOUDFLARE_URL/folder/randomKey`
 | DELETE | `/fcm-tokens` | JWT | Remove FCM token |
 
 ## Shared access check logic
-`SharedFamilyTreeService.checkAccessSharedFamilyTree(userId, familyTreeId, permissions?)`:
-- If user is tree owner → always allowed
-- Else looks up `shared_family_trees` record for this user+tree
-- If blocked → throws 403
-- Checks requested permissions (`canAddMembers`, `canEditMembers`, `canDeleteMembers`)
+Handled by `FamilyTreeAccessGuard` + `@RequirePermission` (see Guards section). The old
+`SharedFamilyTreeService.checkAccessSharedFamilyTree()` god-method was removed (Phase 1 of the
+Isolation ticket — see `.claude/context/isolation-plan.md`):
+- Owner → always allowed
+- Public tree → read-only (any required permission → 403)
+- Shared → looks up `shared_family_trees`; missing/blocked → 403; then every required flag must be true
+- Members + connections + the shared-users RBAC PUT all enforce via the guard now.
+- NOTE: `family-tree.controller` `GET/:id` (inline owner|public check) and `PUT`/`DELETE` (service-level `WHERE createdBy`) were intentionally left as-is — they get dedicated guards in Phase 2 route isolation.

--- a/.claude/context/implementation-log.md
+++ b/.claude/context/implementation-log.md
@@ -24,3 +24,19 @@ Append a bullet here after each session with: date, what was built/changed, and 
 - **Key note:** Prod Swagger broke because the production api build had `optimization: true`, which minifies/mangles DTO class names. `nestjs-zod` + `@nestjs/swagger` name OpenAPI component schemas after the DTO class name, so mangling collapsed every schema into collisions → all endpoints showed one shared schema, params disappeared. Fix: `optimization: false` in `apps/api/project.json` production config. Local was fine because `nx serve` uses the development config (no minification).
 - **Key note:** The `@nx/rspack:rspack` executor controls minification via `project.json`'s `optimization` flag and **overrides** anything set in `apps/api/rspack.config.js` (tried `optimization.minimizer` and `optimization.minimize: false` there — both ignored). Configure build optimization in `project.json`, not the rspack config.
 - **Key note:** Swagger basic-auth in `apps/api/src/config/swagger/swagger.config.ts` is hardcoded `admin`/`password` — unresolved, worth moving to env vars.
+
+---
+
+## 2026-06-14 — Isolation ticket: Phase 1 (access-control layer)
+- Wrote the full 3-phase isolation plan to `.claude/context/isolation-plan.md` (route prefixes `/`=owner, `/public`, `/shared`; guards enforce mode; services stay pure; frontend = thin pages + shared widget). Locked decisions: separate `/public` prefix, owner stays at bare path.
+- Implemented **Phase 1** on branch `feature/isolation-access-guards` (off `develop`):
+  - Created `common/decorators/require-permission.decorator.ts` — variadic `@RequirePermission('canAddMembers', ...)`.
+  - Created `common/guards/family-tree-access.guard.ts` — `FamilyTreeAccessGuard` (owner→public→shared branching, reads required flags from decorator metadata via `Reflector`).
+  - Migrated member, member-connection, and shared-family-tree (RBAC PUT) controllers to `@UseGuards(JWTAuthGuard, FamilyTreeAccessGuard)` + `@RequirePermission`, deleting all inline `checkAccessSharedFamilyTree` calls.
+  - Deleted `checkAccessSharedFamilyTree` from `shared-family-tree.service.ts` (and the `console.log('what the fuck')` debug line inside it).
+  - Registered `FamilyTreeAccessGuard` in the 3 modules' `providers`; dropped the now-unused `SharedFamilyTreeService` from member/connection modules.
+  - Fixed a real security hole: `GET /family-trees/:familyTreeId/members/:memberUserId/connections` had NO access check before — now covered by the class-level guard.
+- **Key note (DI gotcha):** A guard injecting `DrizzleAsyncProvider` MUST be listed in each consuming module's `providers` (DrizzleModule imported there) — otherwise Nest can't resolve it. `Reflector` injects fine but Biome flags it as type-only; needs `// biome-ignore lint/style/useImportType` (same pattern the codebase already uses for `@Body`/`@Query` DTO and service imports — `import type` breaks Nest DI metadata emission).
+- **Key note (guard ordering):** `FamilyTreeAccessGuard` reads `req.user`, so it MUST be listed after `JWTAuthGuard` in `@UseGuards(...)`. Public-but-unauthenticated access is NOT possible yet — current routes still require JWT; true anon `/public` access arrives in Phase 2 with a JWT-less `PublicGuard`.
+- **Key note (intentional scope):** Phase 1 is behavior-preserving except the connections-route fix + debug-log removal. `family-tree.controller` `GET/:id`/`PUT`/`DELETE` were deliberately NOT touched — they're owner-only and belong with the Phase 2 route split (the unified guard would have wrongly granted shared/public users read on `GET/:id`).
+- Verified: `pnpm biome check` clean, `nx run api:build:development` compiles.

--- a/.claude/context/isolation-plan.md
+++ b/.claude/context/isolation-plan.md
@@ -1,0 +1,156 @@
+# Isolation Ticket — Implementation Plan
+
+> Goal: stop deciding owner/public/shared access in three different places. Encode the
+> **access mode in the route prefix**, enforce it with **Guards**, keep **services pure**,
+> and collapse the **~95% duplicated frontend pages** into shared components.
+
+## Decisions (locked)
+- **Public** gets a dedicated prefix: `/family-trees/:id/public/...` (PublicGuard, no JWT, read-only).
+- **Owner** stays at the bare path `/family-trees/:id` (no `/private` prefix — no breaking change).
+- **Shared** uses `/family-trees/:id/shared/...` (SharedAccessGuard + RBAC).
+- Services are **not** touched for access logic — they remain pure, keyed by `familyTreeId`.
+
+## Final route map
+```
+OWNER     /family-trees/:id                              (JWTAuthGuard + OwnerGuard)
+          /family-trees/:familyTreeId/members/**         read + write
+          /family-trees/:familyTreeId/members/connections
+
+PUBLIC    /family-trees/:id/public                       (PublicGuard, no JWT, READ-ONLY)
+          /family-trees/:familyTreeId/public/members     read only
+          /family-trees/:familyTreeId/public/members/connections
+
+SHARED    /family-trees/:id/shared                       (JWTAuthGuard + SharedAccessGuard)
+          /family-trees/:familyTreeId/shared/members/**  read + write (RBAC-gated)
+          /family-trees/:familyTreeId/shared/members/connections
+```
+
+---
+
+## Current problems being fixed
+1. Access mode decided 3 ways: inline `if` in `family-tree.controller` (`GET /:id`), `WHERE createdBy = userId` inside the service (PUT/DELETE), and the god-method `checkAccessSharedFamilyTree(userId, treeId, perms?)` for members/connections.
+2. `checkAccessSharedFamilyTree` branches owner→public→shared in one method — the thing we want to split.
+3. **Security hole**: `GET /family-trees/:familyTreeId/members/:memberUserId/connections` has NO access check (family-tree-member-connection.controller.ts).
+4. Debug log `console.log('what the fuck')` in shared-family-tree.service.ts (~line 280).
+5. Frontend `trees-detail` vs `shared-trees-detail` ≈ 95% copy-paste; differ only in (a) which API fetches the tree, (b) how permissions are derived.
+
+---
+
+## PHASE 1 — Backend access layer (guards replace branching)
+
+### New: `@RequirePermission()` decorator
+- Metadata key e.g. `REQUIRED_PERMISSION`. Value ∈ `'canAddMembers' | 'canEditMembers' | 'canDeleteMembers'`.
+- Set with `Reflector` / `SetMetadata`.
+
+### New guards (in `modules/common/guards/` or shared-family-tree module)
+- **`OwnerGuard`** — load tree by `familyTreeId`/`id`; assert `tree.createdBy === req.user.id`; 404 if missing, 403 otherwise. Stash tree on `req` to avoid re-fetch.
+- **`PublicGuard`** — load tree; assert `tree.isPublic === true`; else 403/404. No JWT dependency.
+- **`SharedAccessGuard`** — load shared record for (`familyTreeId`, `userId`); 403 if missing or `isBlocked`; read `@RequirePermission` metadata via `Reflector` and assert the matching flag is true. (No metadata = read-only access, allowed.)
+
+### Decompose `checkAccessSharedFamilyTree`
+- Delete the method; move owner-bypass/public/shared logic into the three guards.
+- Keep the shared-family-tree **service** data methods: `getSharedFamilyTrees`, `getSharedFamilyTreeById`, `getSharedFamilyTreeUsersById`, `updateSharedFamilyTreeById`, `createSharedFamilyTree`.
+
+### Fixes folded in
+- Add a guard to the previously-unguarded `members/:memberUserId/connections` route.
+- Remove the `console.log('what the fuck')` debug line.
+
+### Acceptance
+- Owner can do everything on bare path; shared user gated by RBAC flags; public user (even unauthenticated) can only read; blocked shared user gets 403 everywhere.
+
+---
+
+## PHASE 2 — Backend route isolation (DRY controllers)
+
+### Abstract base controllers (handler bodies written ONCE)
+Split read tier vs write tier so public can't inherit writes:
+
+```ts
+abstract class BaseMemberReadController {           // GET only
+  @Get()              getAll()
+  @Get('connections') connections()                 // from connection controller, merged here logically
+  @Get(':id')         getOne()
+}
+abstract class BaseMemberWriteController extends BaseMemberReadController {
+  @RequirePermission('canAddMembers')    @Post('child')   child()
+  @RequirePermission('canAddMembers')    @Post('spouse')  spouse()
+  @RequirePermission('canAddMembers')    @Post('parents') parents()
+  @RequirePermission('canEditMembers')   @Put(':id')      update()
+  @RequirePermission('canDeleteMembers') @Delete(':id')   remove()
+}
+```
+
+### Concrete controllers — differ ONLY in prefix + guards
+```ts
+@Controller('family-trees/:familyTreeId/members')        @UseGuards(JWTAuthGuard, OwnerGuard)
+class OwnerMemberController  extends BaseMemberWriteController {}
+
+@Controller('family-trees/:familyTreeId/shared/members') @UseGuards(JWTAuthGuard, SharedAccessGuard)
+class SharedMemberController extends BaseMemberWriteController {}
+
+@Controller('family-trees/:familyTreeId/public/members')  // read-only tier
+class PublicMemberController extends BaseMemberReadController {}
+```
+Apply the same pattern to the family-tree root controller (owner/public/shared `GET /:id`) and connections.
+Register all concrete controllers in their modules.
+
+### Route ordering caution
+`/shared` and `/public` are literal segments under `/family-trees/:id/...`. Ensure the shared-family-tree controller's `GET /family-trees/shared` (list) and `:familyTreeId/shared` don't collide with the new prefixes — verify NestJS route matching order; literal segments win over params, but test `shared` list vs `:id/shared`.
+
+### Caching — confirmed NON-breaking
+- Keys are **data-scoped, not access-scoped**: `family-trees:${treeId}:members` and `...:members:connections` (keyed only by `treeId`). All three modes correctly share one cache entry.
+- **Only change**: broaden path matching in `family-tree.cache.interceptor.ts` so `/public/members` and `/shared/members` resolve to the same `treeId`-based key. No new invalidation logic.
+- List cache `users:${userId}:family-trees:${query}` already includes `isPublic` — unchanged.
+
+### Acceptance
+- Swagger shows isolated owner/public/shared groups. No handler body duplicated. All existing owner URLs still work.
+
+---
+
+## PHASE 3 — Frontend (FSD: thin pages, shared widget)
+
+### Normalize permissions
+Replace `$isOwner` (owner) vs `sharedTree?.canEditMembers` (shared) with one computed store:
+```ts
+$permissions = { canAdd, canEdit, canDelete, canManageSharedUsers }
+// owner  → all true
+// shared → mapped from API flags, canManageSharedUsers: false
+// public → all false
+```
+
+### One parameterized model factory
+`shared` (or `entities/tree`) exposes:
+```ts
+createTreeDetailModel({
+  fetchTree,            // api.tree.findById | api.sharedTree.findById | api.publicTree.findById
+  resolvePermissions,   // (tree, user) => Permissions
+  route,
+})
+```
+Members/connections fetch + add/edit/delete wiring (identical today) lives here once.
+
+### Extract visualization → `widgets/tree-visualization/`
+- Component reads `$permissions` instead of `isOwnerRef` / `canAddMembersRef`.
+- Add-parents/spouse/child buttons gate on `permissions.canAdd`.
+- Edit/delete slots gate on `permissions.canEdit` / `permissions.canDelete`.
+- "Shared Users" toolbar link gates on `permissions.canManageSharedUsers`.
+
+### Three thin pages (~15 lines each)
+- `pages/tree-owner`     → `/family-trees/:id`
+- `pages/tree-shared`    → `/family-trees/:id/shared`
+- `pages/tree-public`    → `/family-trees/:id/public`
+Each: call factory with its config, render the shared widget.
+
+### API client + routes
+- Add a `scope` arg to member/connection clients so one client builds `/members`, `/shared/members`, or `/public/members` (no duplicate client modules).
+- Add `treesPublicDetail: '/family-trees/:id/public'` to `shared/config/routing.ts`.
+- Add a `publicTree.findById` (or extend `tree`) hitting `/public`.
+
+### Acceptance
+- One visualization component, one model factory. Owner/shared/public pages render correctly with mode-appropriate buttons. No visualization duplication remains.
+
+---
+
+## Out of scope / follow-ups
+- Swagger basic-auth still hardcoded `admin`/`password` (see implementation-log) — not part of this ticket.
+- Consider moving `/family-trees/shared` (list) under a clearer namespace later if collisions are painful.

--- a/apps/api/src/common/decorators/require-permission.decorator.ts
+++ b/apps/api/src/common/decorators/require-permission.decorator.ts
@@ -1,0 +1,23 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * RBAC permission flags on `shared_family_trees` that a route can require.
+ */
+export type FamilyTreePermission =
+  | 'canAddMembers'
+  | 'canEditMembers'
+  | 'canDeleteMembers';
+
+export const REQUIRE_PERMISSION_KEY = 'requireFamilyTreePermission';
+
+/**
+ * Declares which shared-tree permission(s) a route needs. Read by
+ * `FamilyTreeAccessGuard`:
+ * - the owner always passes (flags ignored)
+ * - a public tree only passes when NO permission is required (read-only)
+ * - a shared user must hold every listed flag (and not be blocked)
+ *
+ * Omit the decorator entirely for read-only routes.
+ */
+export const RequirePermission = (...permissions: FamilyTreePermission[]) =>
+  SetMetadata(REQUIRE_PERMISSION_KEY, permissions);

--- a/apps/api/src/common/guards/family-tree-access.guard.ts
+++ b/apps/api/src/common/guards/family-tree-access.guard.ts
@@ -1,0 +1,99 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+// biome-ignore lint/style/useImportType: <Reflector is injected via DI>
+import { Reflector } from '@nestjs/core';
+import { and, eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { DrizzleAsyncProvider } from '~/database/drizzle.provider';
+import * as schema from '~/database/schema';
+import type { AuthenticatedRequest } from '~/shared/types/request-with-user';
+import {
+  type FamilyTreePermission,
+  REQUIRE_PERMISSION_KEY,
+} from '../decorators/require-permission.decorator';
+
+/**
+ * Centralizes owner / public / shared access for any route nested under a
+ * family tree (params `familyTreeId` or `id`). Replaces the former
+ * `SharedFamilyTreeService.checkAccessSharedFamilyTree` god-method.
+ *
+ * Must run after `JWTAuthGuard` (relies on `req.user`).
+ *
+ * NOTE: in Phase 2 the route prefixes (`/`, `/public`, `/shared`) get their own
+ * dedicated guards; the three branches below are the seam where that split happens.
+ */
+@Injectable()
+export class FamilyTreeAccessGuard implements CanActivate {
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: NodePgDatabase<typeof schema>,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const familyTreeId = request.params.familyTreeId ?? request.params.id;
+    const userId = request.user.id;
+
+    const requiredPermissions =
+      this.reflector.getAllAndOverride<FamilyTreePermission[]>(
+        REQUIRE_PERMISSION_KEY,
+        [context.getHandler(), context.getClass()],
+      ) ?? [];
+
+    const familyTree = await this.db.query.familyTreesSchema.findFirst({
+      where: eq(schema.familyTreesSchema.id, familyTreeId),
+      columns: { createdBy: true, isPublic: true },
+    });
+
+    if (!familyTree) {
+      throw new NotFoundException(
+        `Family tree with id ${familyTreeId} not found`,
+      );
+    }
+
+    // owner: full access
+    if (familyTree.createdBy === userId) {
+      return true;
+    }
+
+    // public: anyone may read, nobody but the owner may write
+    if (familyTree.isPublic) {
+      if (requiredPermissions.length > 0) {
+        throw new ForbiddenException(`You don't have a permission`);
+      }
+
+      return true;
+    }
+
+    // shared: needs a non-blocked record holding every required flag
+    const access = await this.db.query.sharedFamilyTreesSchema.findFirst({
+      where: and(
+        eq(schema.sharedFamilyTreesSchema.familyTreeId, familyTreeId),
+        eq(schema.sharedFamilyTreesSchema.userId, userId),
+      ),
+      columns: {
+        canAddMembers: true,
+        canEditMembers: true,
+        canDeleteMembers: true,
+        isBlocked: true,
+      },
+    });
+
+    if (!access || access.isBlocked) {
+      throw new ForbiddenException(`You don't have a permission`);
+    }
+
+    if (requiredPermissions.some((permission) => !access[permission])) {
+      throw new ForbiddenException(`You don't have a permission`);
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/modules/family-tree-member-connection/family-tree-member-connection.controller.ts
+++ b/apps/api/src/modules/family-tree-member-connection/family-tree-member-connection.controller.ts
@@ -5,7 +5,6 @@ import {
   HttpCode,
   HttpStatus,
   Param,
-  Req,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
@@ -15,12 +14,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger/dist/decorators';
 import { ZodSerializerDto } from 'nestjs-zod';
+import { FamilyTreeAccessGuard } from '~/common/guards/family-tree-access.guard';
 import { JWTAuthGuard } from '~/common/guards/jwt-auth.guard';
 import { FamilyTreeCacheInterceptor } from '~/common/interceptors/family-tree.cache.interceptor';
-import type { AuthenticatedRequest } from '~/shared/types/request-with-user';
 import { COOKIES_ACCESS_TOKEN_KEY } from '~/utils/constants';
-// biome-ignore lint/style/useImportType: <throws an error if put type>
-import { SharedFamilyTreeService } from '../shared-family-tree/shared-family-tree.service';
 // biome-ignore lint/style/useImportType: <query/param doesn't work>
 import {
   FamilyTreeMemberConnectionGetAllParamDto,
@@ -31,31 +28,23 @@ import {
 import { FamilyTreeMemberConnectionService } from './family-tree-member-connection.service';
 
 @ApiTags('Family Tree Member Connection')
+@ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
 @Controller('family-trees/:familyTreeId/members')
+@UseGuards(JWTAuthGuard, FamilyTreeAccessGuard)
 @UseInterceptors(FamilyTreeCacheInterceptor)
 export class FamilyTreeMemberConnectionController {
   constructor(
     private readonly familyTreeMemberConnectionService: FamilyTreeMemberConnectionService,
-    private readonly sharedFamilyTreeService: SharedFamilyTreeService,
   ) {}
 
   // get all connections of tree
   @Get('connections')
-  @UseGuards(JWTAuthGuard)
-  @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
   @HttpCode(HttpStatus.OK)
   @ApiOkResponse({ type: FamilyTreeMemberConnectionGetAllResponseDto })
   @ZodSerializerDto(FamilyTreeMemberConnectionGetAllResponseSchema)
   async getAllFamilyTreeMemberConnections(
-    @Req() req: AuthenticatedRequest,
     @Param() param: FamilyTreeMemberConnectionGetAllParamDto,
   ): Promise<FamilyTreeMemberConnectionGetAllResponseDto> {
-    // check access
-    await this.sharedFamilyTreeService.checkAccessSharedFamilyTree(
-      req.user.id,
-      param.familyTreeId,
-    );
-
     return this.familyTreeMemberConnectionService.getAllFamilyTreeMemberConnections(
       param,
     );
@@ -63,8 +52,6 @@ export class FamilyTreeMemberConnectionController {
 
   // get connection of member in tree
   @Get(':memberUserId/connections')
-  @UseGuards(JWTAuthGuard)
-  @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
   @HttpCode(HttpStatus.OK)
   @ApiOkResponse({ type: FamilyTreeMemberConnectionGetAllResponseDto })
   @ZodSerializerDto(FamilyTreeMemberConnectionGetAllResponseSchema)

--- a/apps/api/src/modules/family-tree-member-connection/family-tree-member-connection.module.ts
+++ b/apps/api/src/modules/family-tree-member-connection/family-tree-member-connection.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
+import { FamilyTreeAccessGuard } from '~/common/guards/family-tree-access.guard';
 import { DrizzleModule } from '~/database/drizzle.module';
-import { SharedFamilyTreeService } from '../shared-family-tree/shared-family-tree.service';
 import { FamilyTreeMemberConnectionController } from './family-tree-member-connection.controller';
 import { FamilyTreeMemberConnectionService } from './family-tree-member-connection.service';
 
 @Module({
   imports: [DrizzleModule],
   controllers: [FamilyTreeMemberConnectionController],
-  providers: [FamilyTreeMemberConnectionService, SharedFamilyTreeService],
+  providers: [FamilyTreeMemberConnectionService, FamilyTreeAccessGuard],
 })
 export class FamilyTreeMemberConnectionModule {}

--- a/apps/api/src/modules/family-tree-member/family-tree-member.controller.ts
+++ b/apps/api/src/modules/family-tree-member/family-tree-member.controller.ts
@@ -12,7 +12,6 @@ import {
   Param,
   Post,
   Put,
-  Req,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
@@ -24,12 +23,11 @@ import {
   ApiTags,
 } from '@nestjs/swagger/dist/decorators';
 import { ZodSerializerDto } from 'nestjs-zod';
+import { RequirePermission } from '~/common/decorators/require-permission.decorator';
+import { FamilyTreeAccessGuard } from '~/common/guards/family-tree-access.guard';
 import { JWTAuthGuard } from '~/common/guards/jwt-auth.guard';
 import { FamilyTreeCacheInterceptor } from '~/common/interceptors/family-tree.cache.interceptor';
-import type { AuthenticatedRequest } from '~/shared/types/request-with-user';
 import { COOKIES_ACCESS_TOKEN_KEY } from '~/utils/constants';
-// biome-ignore lint/style/useImportType: <throws an error if put type>
-import { SharedFamilyTreeService } from '../shared-family-tree/shared-family-tree.service';
 // biome-ignore lint/style/useImportType: <query/param doesn't work>
 import {
   FamilyTreeMemberCreateChildRequestDto,
@@ -45,35 +43,25 @@ import {
 import { FamilyTreeMemberService } from './family-tree-member.service';
 
 @ApiTags('Family Tree Member')
+@ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
 @Controller('family-trees/:familyTreeId/members')
+@UseGuards(JWTAuthGuard, FamilyTreeAccessGuard)
 @UseInterceptors(FamilyTreeCacheInterceptor)
 export class FamilyTreeMemberController {
   constructor(
     private readonly familyTreeMemberService: FamilyTreeMemberService,
-    private readonly sharedFamilyTreeService: SharedFamilyTreeService,
   ) {}
 
   // add member create (child)
   @Post('child')
-  @UseGuards(JWTAuthGuard)
-  @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
+  @RequirePermission('canAddMembers')
   @HttpCode(HttpStatus.CREATED)
   @ApiCreatedResponse({ type: FamilyTreeMemberGetResponseDto })
   @ZodSerializerDto(FamilyTreeMemberGetResponseSchema)
   async createFamilyTreeMemberChild(
-    @Req() req: AuthenticatedRequest,
     @Body() body: FamilyTreeMemberCreateChildRequestDto,
     @Param() param: FamilyTreeMemberGetAllParamDto,
   ): Promise<FamilyTreeMemberGetResponseDto> {
-    // check access
-    await this.sharedFamilyTreeService.checkAccessSharedFamilyTree(
-      req.user.id,
-      param.familyTreeId,
-      {
-        canAddMembers: true,
-      },
-    );
-
     return this.familyTreeMemberService.createFamilyTreeMemberChild(
       param.familyTreeId,
       body,
@@ -82,25 +70,14 @@ export class FamilyTreeMemberController {
 
   // add member create (spouse)
   @Post('spouse')
-  @UseGuards(JWTAuthGuard)
-  @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
+  @RequirePermission('canAddMembers')
   @HttpCode(HttpStatus.CREATED)
   @ApiCreatedResponse({ type: FamilyTreeMemberGetResponseDto })
   @ZodSerializerDto(FamilyTreeMemberGetResponseSchema)
   async createFamilyTreeMemberSpouse(
-    @Req() req: AuthenticatedRequest,
     @Body() body: FamilyTreeMemberCreateSpouseRequestDto,
     @Param() param: FamilyTreeMemberGetAllParamDto,
   ): Promise<FamilyTreeMemberGetResponseDto> {
-    // check access
-    await this.sharedFamilyTreeService.checkAccessSharedFamilyTree(
-      req.user.id,
-      param.familyTreeId,
-      {
-        canAddMembers: true,
-      },
-    );
-
     return this.familyTreeMemberService.createFamilyTreeMemberSpouse(
       param.familyTreeId,
       body,
@@ -109,25 +86,14 @@ export class FamilyTreeMemberController {
 
   // add member create (parents)
   @Post('parents')
-  @UseGuards(JWTAuthGuard)
-  @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
+  @RequirePermission('canAddMembers')
   @HttpCode(HttpStatus.CREATED)
   @ApiCreatedResponse({ type: FamilyTreeMemberGetResponseDto })
   @ZodSerializerDto(FamilyTreeMemberGetResponseSchema)
   async createFamilyTreeMemberParents(
-    @Req() req: AuthenticatedRequest,
     @Body() body: FamilyTreeMemberCreateParentsRequestDto,
     @Param() param: FamilyTreeMemberGetAllParamDto,
   ): Promise<FamilyTreeMemberGetResponseDto> {
-    // check access
-    await this.sharedFamilyTreeService.checkAccessSharedFamilyTree(
-      req.user.id,
-      param.familyTreeId,
-      {
-        canAddMembers: true,
-      },
-    );
-
     return this.familyTreeMemberService.createFamilyTreeMemberParents(
       param.familyTreeId,
       body,
@@ -136,86 +102,46 @@ export class FamilyTreeMemberController {
 
   // edit member user
   @Put(':id')
-  @UseGuards(JWTAuthGuard)
-  @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
+  @RequirePermission('canEditMembers')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiNoContentResponse()
   async updateFamilyTreeMember(
-    @Req() req: AuthenticatedRequest,
     @Param() param: FamilyTreeMemberGetParamDto,
     @Body() body: FamilyTreeMemberUpdateRequestDto,
   ): Promise<void> {
-    // check access
-    await this.sharedFamilyTreeService.checkAccessSharedFamilyTree(
-      req.user.id,
-      param.familyTreeId,
-      {
-        canEditMembers: true,
-      },
-    );
-
     return this.familyTreeMemberService.updateFamilyTreeMember(param, body);
   }
 
   // delete member user
   @Delete(':id')
-  @UseGuards(JWTAuthGuard)
-  @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
+  @RequirePermission('canDeleteMembers')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiNoContentResponse()
   async deleteFamilyTreeMember(
-    @Req() req: AuthenticatedRequest,
     @Param() param: FamilyTreeMemberGetParamDto,
   ): Promise<void> {
-    // check access
-    await this.sharedFamilyTreeService.checkAccessSharedFamilyTree(
-      req.user.id,
-      param.familyTreeId,
-      {
-        canDeleteMembers: true,
-      },
-    );
-
     return this.familyTreeMemberService.deleteFamilyTreeMember(param);
   }
 
   // get all nodes of tree
   @Get()
-  @UseGuards(JWTAuthGuard)
-  @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
   @HttpCode(HttpStatus.OK)
   @ApiOkResponse({ type: FamilyTreeMemberGetAllResponseDto })
   @ZodSerializerDto(FamilyTreeMemberGetAllResponseSchema)
   async getAllFamilyTreeMembers(
-    @Req() req: AuthenticatedRequest,
     @Param() param: FamilyTreeMemberGetAllParamDto,
   ): Promise<FamilyTreeMemberGetAllResponseDto> {
-    // check access
-    await this.sharedFamilyTreeService.checkAccessSharedFamilyTree(
-      req.user.id,
-      param.familyTreeId,
-    );
-
     return this.familyTreeMemberService.getAllFamilyTreeMembers(param);
   }
 
   // get node by id and tree
   @Get(':id')
-  @UseGuards(JWTAuthGuard)
-  @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
   @HttpCode(HttpStatus.OK)
   @ApiOkResponse({ type: FamilyTreeMemberGetResponseDto })
   @ZodSerializerDto(FamilyTreeMemberGetResponseSchema)
   async getFamilyTreeMember(
-    @Req() req: AuthenticatedRequest,
     @Param() param: FamilyTreeMemberGetParamDto,
   ): Promise<FamilyTreeMemberGetResponseDto> {
-    // check access
-    await this.sharedFamilyTreeService.checkAccessSharedFamilyTree(
-      req.user.id,
-      param.familyTreeId,
-    );
-
     return this.familyTreeMemberService.getFamilyTreeMember(param);
   }
 }

--- a/apps/api/src/modules/family-tree-member/family-tree-member.module.ts
+++ b/apps/api/src/modules/family-tree-member/family-tree-member.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
+import { FamilyTreeAccessGuard } from '~/common/guards/family-tree-access.guard';
 import { CloudflareModule } from '~/config/cloudflare/cloudflare.module';
 import { DrizzleModule } from '~/database/drizzle.module';
-import { SharedFamilyTreeService } from '../shared-family-tree/shared-family-tree.service';
 import { FamilyTreeMemberController } from './family-tree-member.controller';
 import { FamilyTreeMemberService } from './family-tree-member.service';
 
 @Module({
   imports: [DrizzleModule, CloudflareModule],
   controllers: [FamilyTreeMemberController],
-  providers: [FamilyTreeMemberService, SharedFamilyTreeService],
+  providers: [FamilyTreeMemberService, FamilyTreeAccessGuard],
 })
 export class FamilyTreeMemberModule {}

--- a/apps/api/src/modules/shared-family-tree/shared-family-tree.controller.ts
+++ b/apps/api/src/modules/shared-family-tree/shared-family-tree.controller.ts
@@ -22,6 +22,8 @@ import {
   ApiTags,
 } from '@nestjs/swagger/dist/decorators';
 import { ZodSerializerDto } from 'nestjs-zod';
+import { RequirePermission } from '~/common/decorators/require-permission.decorator';
+import { FamilyTreeAccessGuard } from '~/common/guards/family-tree-access.guard';
 import { JWTAuthGuard } from '~/common/guards/jwt-auth.guard';
 import type { AuthenticatedRequest } from '~/shared/types/request-with-user';
 import { COOKIES_ACCESS_TOKEN_KEY } from '~/utils/constants';
@@ -99,28 +101,17 @@ export class SharedFamilyTreeController {
   }
 
   // Update RBAC of the user which is shared with
+  // TODO: in future we might have another option smth like canEditRBAC, so we need to check that one
   @Put(':familyTreeId/shared-users/:userId')
-  @UseGuards(JWTAuthGuard)
+  @UseGuards(JWTAuthGuard, FamilyTreeAccessGuard)
+  @RequirePermission('canEditMembers', 'canAddMembers', 'canDeleteMembers')
   @ApiCookieAuth(COOKIES_ACCESS_TOKEN_KEY)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiNoContentResponse()
   async updateSharedFamilyTreeById(
-    @Req() req: AuthenticatedRequest,
     @Param() param: SharedFamilyTreeUpdateParamDto,
     @Body() body: SharedFamilyTreeUpdateRequestDto,
   ): Promise<void> {
-    // check access (whether he can modify)
-    await this.sharedFamilyTreeService.checkAccessSharedFamilyTree(
-      req.user.id,
-      param.familyTreeId,
-      {
-        // TODO: in future we might have another option smth like canEditRBAC, so we need to check that one
-        canEditMembers: true,
-        canAddMembers: true,
-        canDeleteMembers: true,
-      },
-    );
-
     return this.sharedFamilyTreeService.updateSharedFamilyTreeById(
       param.userId,
       param.familyTreeId,

--- a/apps/api/src/modules/shared-family-tree/shared-family-tree.module.ts
+++ b/apps/api/src/modules/shared-family-tree/shared-family-tree.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { FamilyTreeAccessGuard } from '~/common/guards/family-tree-access.guard';
 import { DrizzleModule } from '~/database/drizzle.module';
 import { SharedFamilyTreeController } from './shared-family-tree.controller';
 import { SharedFamilyTreeService } from './shared-family-tree.service';
@@ -6,6 +7,6 @@ import { SharedFamilyTreeService } from './shared-family-tree.service';
 @Module({
   imports: [DrizzleModule],
   controllers: [SharedFamilyTreeController],
-  providers: [SharedFamilyTreeService],
+  providers: [SharedFamilyTreeService, FamilyTreeAccessGuard],
 })
 export class SharedFamilyTreeModule {}

--- a/apps/api/src/modules/shared-family-tree/shared-family-tree.service.ts
+++ b/apps/api/src/modules/shared-family-tree/shared-family-tree.service.ts
@@ -1,4 +1,3 @@
-import type { SharedFamilyTreeSchemaType } from '@family-tree/shared';
 import {
   ForbiddenException,
   Inject,
@@ -248,74 +247,6 @@ export class SharedFamilyTreeService {
       totalCount,
       totalPages,
     };
-  }
-
-  async checkAccessSharedFamilyTree(
-    userId: string,
-    familyTreeId: string,
-    access?: Partial<
-      Pick<
-        SharedFamilyTreeSchemaType,
-        'canAddMembers' | 'canEditMembers' | 'canDeleteMembers'
-      >
-    >,
-  ): Promise<void> {
-    const familyTree = await this.db.query.familyTreesSchema.findFirst({
-      where: eq(schema.familyTreesSchema.id, familyTreeId),
-      columns: { createdBy: true, isPublic: true },
-    });
-
-    if (!familyTree) {
-      throw new NotFoundException(
-        `Family tree with id ${familyTreeId} not found`,
-      );
-    }
-
-    if (familyTree.createdBy === userId) {
-      return;
-    }
-
-    // public trees: anyone can read, only the owner can write
-    if (familyTree.isPublic) {
-      console.log('what the fuck');
-      if (access) {
-        throw new ForbiddenException(`You don't have a permission`);
-      }
-      return;
-    }
-
-    const sharedFamilyTreeUserAccess =
-      await this.db.query.sharedFamilyTreesSchema.findFirst({
-        where: and(
-          eq(schema.sharedFamilyTreesSchema.familyTreeId, familyTreeId),
-          eq(schema.sharedFamilyTreesSchema.userId, userId),
-        ),
-        columns: {
-          canAddMembers: true,
-          canEditMembers: true,
-          canDeleteMembers: true,
-          isBlocked: true,
-        },
-      });
-
-    if (!sharedFamilyTreeUserAccess || sharedFamilyTreeUserAccess.isBlocked) {
-      throw new ForbiddenException(`You don't have a permission`);
-    }
-
-    if (access?.canAddMembers && !sharedFamilyTreeUserAccess.canAddMembers) {
-      throw new ForbiddenException(`You don't have a permission`);
-    }
-
-    if (access?.canEditMembers && !sharedFamilyTreeUserAccess.canEditMembers) {
-      throw new ForbiddenException(`You don't have a permission`);
-    }
-
-    if (
-      access?.canDeleteMembers &&
-      !sharedFamilyTreeUserAccess.canDeleteMembers
-    ) {
-      throw new ForbiddenException(`You don't have a permission`);
-    }
   }
 
   async updateSharedFamilyTreeById(


### PR DESCRIPTION
## Summary
- Replaced inline `checkAccessSharedFamilyTree` god-method with a single declarative `FamilyTreeAccessGuard` (owner → public → shared branching)
- Introduced `@RequirePermission('canAddMembers', ...)` variadic decorator for write-route RBAC
- Moved class-level `@UseGuards` onto member + connection controllers; removed all per-route inline access checks
- Fixed security hole: `GET /members/:memberUserId/connections` had no access check before
- Deleted `console.log('what the fuck')` debug line from production code

## Changes
| File | What changed |
|---|---|
| `common/decorators/require-permission.decorator.ts` | New — variadic permission decorator |
| `common/guards/family-tree-access.guard.ts` | New — combined owner/public/shared guard |
| `family-tree-member.controller.ts` | Class-level guard, `@RequirePermission` on writes |
| `family-tree-member-connection.controller.ts` | Class-level guard (fixes unguarded connections route) |
| `shared-family-tree.controller.ts` | Uses `FamilyTreeAccessGuard` for RBAC PUT |
| `shared-family-tree.service.ts` | Deleted `checkAccessSharedFamilyTree` |

## Test plan
- [ ] Owner can read + write members and connections
- [ ] Shared user with `canAddMembers=false` gets 403 on POST member routes
- [ ] Shared user with all perms can add/edit/delete
- [ ] Unauthenticated request to member routes gets 401
- [ ] `GET /family-trees/:familyTreeId/members/:memberUserId/connections` requires auth (was open before)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)